### PR TITLE
Problems involving job parameters

### DIFF
--- a/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/api/resource/ResourceToAdminMapper.java
+++ b/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/api/resource/ResourceToAdminMapper.java
@@ -45,22 +45,19 @@ public final class ResourceToAdminMapper {
                 final org.springframework.batch.core.JobParameter.ParameterType parameterType = map(entry.getValue()
                         .getParameterType());
                 final org.springframework.batch.core.JobParameter jobParameter;
+                final String parameter = String.valueOf(entry.getValue().getParameter());
                 switch (parameterType) {
                     case STRING:
-                        jobParameter = new org.springframework.batch.core.JobParameter((String) entry.getValue()
-                                .getParameter());
+                        jobParameter = new org.springframework.batch.core.JobParameter(parameter);
                         break;
                     case DOUBLE:
-                        jobParameter = new org.springframework.batch.core.JobParameter((Double) entry.getValue()
-                                .getParameter());
+                        jobParameter = new org.springframework.batch.core.JobParameter(Double.parseDouble(parameter));
                         break;
                     case LONG:
-                        jobParameter = new org.springframework.batch.core.JobParameter((Long) entry.getValue()
-                                .getParameter());
+                        jobParameter = new org.springframework.batch.core.JobParameter(Long.parseLong(parameter));
                         break;
                     case DATE:
-                        jobParameter = new org.springframework.batch.core.JobParameter((Date) entry.getValue()
-                                .getParameter());
+                        jobParameter = new org.springframework.batch.core.JobParameter(new Date(Long.parseLong(parameter)));
                         break;
                     default:
                         throw new SpringBatchLightminApplicationException("Unknown JobParameterType: " + entry.getValue().getParameterType());

--- a/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/util/ParameterParser.java
+++ b/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/util/ParameterParser.java
@@ -68,7 +68,7 @@ public final class ParameterParser {
                 final Object value = entry.getValue();
                 final String valueType;
                 final String valueString;
-                if (value instanceof Long) {
+                if (value instanceof Long || value instanceof Integer) {
                     valueType = "(Long)";
                     valueString = value.toString();
                 } else if (value instanceof String) {


### PR DESCRIPTION
Hello!

I've been using this wonderful tool that you've made using Spring Boot and Spring Batch. Undoubtedly handir than the old Spring Batch Admin. So, I've been facing this issue when I try to use Job parameters. For example: Using Long parameter with value 1 (which fits in an Integer), when the request arrives in the API, it recognizes it as Integer instead of Long, and there's no Integer mapped on, so it crashes in an ClassCastException (Integer to Long). My solution was just transforming the types instead of casting them (Long.parseLong, etc.). I run the corresponding tests and everything is working.