### PR TITLE
fix(cron): fixing null pointer exception

### DIFF
--- a/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/admin/repository/JdbcJobConfigurationRepository.java
+++ b/spring-batch-lightmin-core/src/main/java/org/tuxdevelop/spring/batch/lightmin/admin/repository/JdbcJobConfigurationRepository.java
@@ -551,10 +551,13 @@ public class JdbcJobConfigurationRepository implements JobConfigurationRepositor
             public static JobSchedulerConfiguration map(final Map<String, Object> values) {
                 final JobSchedulerConfiguration jobSchedulerConfiguration = new JobSchedulerConfiguration();
                 jobSchedulerConfiguration.setBeanName(getValueOrNull(values, JobSchedulerConfigurationKey.BEAN_NAME, String.class));
-                jobSchedulerConfiguration.setCronExpression(getValueOrNull(values, JobSchedulerConfigurationKey.CRON_EXPRESSION, String.class));
-                jobSchedulerConfiguration.setFixedDelay(getValueOrNull(values, JobSchedulerConfigurationKey.FIXED_DELAY, Long.class));
-                jobSchedulerConfiguration.setInitialDelay(getValueOrNull(values, JobSchedulerConfigurationKey.INITIAL_DELAY, Long.class));
                 final JobSchedulerType jobSchedulerType = JobSchedulerType.getById(getValueOrNull(values, JobSchedulerConfigurationKey.SCHEDULER_TYPE, Long.class));
+                if (JobSchedulerType.CRON == jobSchedulerType) {
+                    jobSchedulerConfiguration.setCronExpression(getValueOrNull(values, JobSchedulerConfigurationKey.CRON_EXPRESSION, String.class));
+                } else if (JobSchedulerType.PERIOD == jobSchedulerType) {
+                    jobSchedulerConfiguration.setFixedDelay(getValueOrNull(values, JobSchedulerConfigurationKey.FIXED_DELAY, Long.class));
+                    jobSchedulerConfiguration.setInitialDelay(getValueOrNull(values, JobSchedulerConfigurationKey.INITIAL_DELAY, Long.class));
+                }
                 jobSchedulerConfiguration.setJobSchedulerType(jobSchedulerType);
                 final SchedulerStatus schedulerStatus = SchedulerStatus.getByValue(getValueOrNull(values, JobSchedulerConfigurationKey.STATUS, String.class));
                 jobSchedulerConfiguration.setSchedulerStatus(schedulerStatus);


### PR DESCRIPTION
fixing null pointer exception for cron scheduler type when retrieving value FIXED_DELAY and INITIAL_DELAY that are useless in that case.